### PR TITLE
Add logging config switch

### DIFF
--- a/java/squeek/spiceoflife/ModConfig.java
+++ b/java/squeek/spiceoflife/ModConfig.java
@@ -39,6 +39,16 @@ public class ModConfig implements IPackable, IPacketProcessor {
     private static final boolean FOOD_MODIFIER_ENABLED_DEFAULT = true;
     private static final String FOOD_MODIFIER_ENABLED_COMMENT = "If false, disables the entire diminishing returns part of the mod";
     /*
+     * DEV
+     */
+    private static final String CATEGORY_DEV = "dev";
+    private static final String CATEGORY_DEV_COMMENT =
+            "These config settings are only for developers";
+    private static final String DEV_LOGGING_ENABLED_NAME = "dev.logging.enabled";
+    private static final boolean DEV_LOGGING_ENABLED_DEFAULT = false;
+    private static final String DEV_LOGGING_ENABLED_COMMENT = "If true, enables extra logging to help modpack developers";
+    public static boolean DEV_LOGGING_ENABLED = ModConfig.DEV_LOGGING_ENABLED_DEFAULT;
+    /*
      * SERVER
      */
     private static final String CATEGORY_SERVER = "server";
@@ -188,6 +198,13 @@ public class ModConfig implements IPackable, IPacketProcessor {
         // only use the config value immediately when server-side; the client assumes false until the server syncs the config
         if (FMLCommonHandler.instance().getSide() == Side.SERVER)
             FOOD_MODIFIER_ENABLED = FOOD_MODIFIER_ENABLED_CONFIG_VAL;
+
+        /*
+         * DEV
+         */
+        config.getCategory(CATEGORY_DEV).setComment(CATEGORY_DEV_COMMENT);
+
+        DEV_LOGGING_ENABLED = config.get(CATEGORY_DEV, DEV_LOGGING_ENABLED_NAME, DEV_LOGGING_ENABLED_DEFAULT, DEV_LOGGING_ENABLED_COMMENT).getBoolean(DEV_LOGGING_ENABLED_DEFAULT);
 
         /*
          * SERVER

--- a/java/squeek/spiceoflife/foodtracker/FoodLists.java
+++ b/java/squeek/spiceoflife/foodtracker/FoodLists.java
@@ -3,6 +3,7 @@ package squeek.spiceoflife.foodtracker;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 import squeek.applecore.api.food.FoodValues;
+import squeek.spiceoflife.ModConfig;
 import squeek.spiceoflife.ModSpiceOfLife;
 import squeek.spiceoflife.helpers.FoodHelper;
 
@@ -17,7 +18,8 @@ public final class FoodLists {
     private static List<ItemStack> allFoods;
 
     public static void setUp() {
-        ModSpiceOfLife.Log.info("Starting populating food list.");
+        if(ModConfig.DEV_LOGGING_ENABLED)
+            ModSpiceOfLife.Log.info("Starting populating food list.");
         Stream<Item> stream = StreamSupport.stream(Item.itemRegistry.spliterator(), false);
         allFoods = stream
             .map(ItemStack::new)
@@ -27,9 +29,11 @@ public final class FoodLists {
 
         allFoods.forEach((i -> {
             FoodValues fv = FoodHelper.getFoodValues(i);
-            ModSpiceOfLife.Log.info(i.getDisplayName() + ", " + fv.hunger + ", " + fv.saturationModifier);
+            if(ModConfig.DEV_LOGGING_ENABLED)
+                ModSpiceOfLife.Log.info(i.getDisplayName() + ", " + fv.hunger + ", " + fv.saturationModifier);
         }));
-        ModSpiceOfLife.Log.info("Done populating food list.");
+        if(ModConfig.DEV_LOGGING_ENABLED)
+            ModSpiceOfLife.Log.info("Done populating food list.");
     }
 
     public static List<ItemStack> getAllFoods() {


### PR DESCRIPTION
A lot of extraneous logging is created during mod initilization, this PR simply adds a config (default: false) to toggle the logging on. A new configuration category was added, as it did not fit into others as it should not be synced and is not client-only.