### PR TITLE
Rename Lunch Box to Bento Box

### DIFF
--- a/src/main/resources/assets/spiceoflife/lang/en_US.lang
+++ b/src/main/resources/assets/spiceoflife/lang/en_US.lang
@@ -45,5 +45,5 @@ spiceoflife.gui.food_history.next_heart=until next heart:
 
 # Items
 item.spiceoflife.bookfoodjournal.name=Food Journal
-item.spiceoflife.lunchbox.name=Lunch Box
+item.spiceoflife.lunchbox.name=Bento Box
 item.spiceoflife.lunchbag.name=Lunch Bag


### PR DESCRIPTION
In general, Lunch Box usually means a box stuffed with Sandwiches or Hamburgers without any care about nutrient
However, this mod "encourages dietary variety" as you see in github description.
[Bento Box](https://en.wikipedia.org/wiki/Bento) exists for that purpose.

According to [this website](https://justbento.com/handbook/bento-basics/great-question-whats-difference-between-lunch-box-and-bento),
Bento Box is:

> having a variety of textures, flavors, food groups and colors inside a small container
> packing things tightly for compactness and to ensure that things don't move around
> the way to pack a box so that it looks appetizing when it's opened
> what tastes good several hours after packing, and (mostly) at room temperature

It can explain what the SOL Lunch box currently is

Lunch Bag is fine as it only contains three kinds of foods
