### PR TITLE
feat: readd use.hunger.restored.for.food.history.length config option

### DIFF
--- a/src/main/java/squeek/spiceoflife/ModConfig.java
+++ b/src/main/java/squeek/spiceoflife/ModConfig.java
@@ -143,10 +143,15 @@ public class ModConfig implements IPackable, IPacketProcessor {
         + " is > 0, a food with 0% nutrtional value will take nearly infinite time to eat";
     private static final String USE_HUNGER_QUEUE_NAME = "use.hunger.restored.for.food.history.length";
     private static final boolean USE_HUNGER_QUEUE_DEFAULT = false;
-    private static final String USE_HUNGER_QUEUE_COMMENT = "If true, " + FOOD_HISTORY_LENGTH_NAME + " will use amount of hunger restored instead of number of foods eaten for its maximum length\n"
-        + "For example, a " + FOOD_HISTORY_LENGTH_NAME + " length of 12 will store a max of 2 foods that restored 6 hunger each, \n"
+    private static final String USE_HUNGER_QUEUE_COMMENT = "If true, " + FOOD_HISTORY_LENGTH_NAME
+        + " will use amount of hunger restored instead of number of foods eaten for its maximum length\n"
+        + "For example, a "
+        + FOOD_HISTORY_LENGTH_NAME
+        + " length of 12 will store a max of 2 foods that restored 6 hunger each, \n"
         + "3 foods that restored 4 hunger each, 12 foods that restored 1 hunger each, etc\n"
-        + "NOTE: " + FOOD_HISTORY_LENGTH_NAME + " uses hunger units, where 1 hunger unit = 1/2 hunger bar";
+        + "NOTE: "
+        + FOOD_HISTORY_LENGTH_NAME
+        + " uses hunger units, where 1 hunger unit = 1/2 hunger bar";
     private static final String FOOD_MODIFIER_FORMULA_STRING_NAME = "food.modifier.formula";
     private static final String FOOD_MODIFIER_FORMULA_STRING_DEFAULT = "MAX(0, (1 - count/12))^MIN(8, food_hunger_value)";
     private static final String FOOD_MODIFIER_FORMULA_STRING_COMMENT = "Uses the EvalEx expression parser\n"
@@ -365,7 +370,9 @@ public class ModConfig implements IPackable, IPacketProcessor {
                 FOOD_EATING_DURATION_MAX_DEFAULT,
                 FOOD_EATING_DURATION_MAX_COMMENT)
             .getInt(FOOD_EATING_DURATION_MAX_DEFAULT);
-        USE_HUNGER_QUEUE = config.get(CATEGORY_SERVER, USE_HUNGER_QUEUE_NAME, USE_HUNGER_QUEUE_DEFAULT, USE_HUNGER_QUEUE_COMMENT).getBoolean(USE_HUNGER_QUEUE_DEFAULT);
+        USE_HUNGER_QUEUE = config
+            .get(CATEGORY_SERVER, USE_HUNGER_QUEUE_NAME, USE_HUNGER_QUEUE_DEFAULT, USE_HUNGER_QUEUE_COMMENT)
+            .getBoolean(USE_HUNGER_QUEUE_DEFAULT);
         GIVE_FOOD_JOURNAL_ON_START = config
             .get(
                 CATEGORY_SERVER,

--- a/src/main/java/squeek/spiceoflife/ModConfig.java
+++ b/src/main/java/squeek/spiceoflife/ModConfig.java
@@ -141,6 +141,12 @@ public class ModConfig implements IPackable, IPacketProcessor {
         + "Note: If this is set to 0 and "
         + ModConfig.FOOD_EATING_SPEED_MODIFIER_NAME
         + " is > 0, a food with 0% nutrtional value will take nearly infinite time to eat";
+    private static final String USE_HUNGER_QUEUE_NAME = "use.hunger.restored.for.food.history.length";
+    private static final boolean USE_HUNGER_QUEUE_DEFAULT = false;
+    private static final String USE_HUNGER_QUEUE_COMMENT = "If true, " + FOOD_HISTORY_LENGTH_NAME + " will use amount of hunger restored instead of number of foods eaten for its maximum length\n"
+        + "For example, a " + FOOD_HISTORY_LENGTH_NAME + " length of 12 will store a max of 2 foods that restored 6 hunger each, \n"
+        + "3 foods that restored 4 hunger each, 12 foods that restored 1 hunger each, etc\n"
+        + "NOTE: " + FOOD_HISTORY_LENGTH_NAME + " uses hunger units, where 1 hunger unit = 1/2 hunger bar";
     private static final String FOOD_MODIFIER_FORMULA_STRING_NAME = "food.modifier.formula";
     private static final String FOOD_MODIFIER_FORMULA_STRING_DEFAULT = "MAX(0, (1 - count/12))^MIN(8, food_hunger_value)";
     private static final String FOOD_MODIFIER_FORMULA_STRING_COMMENT = "Uses the EvalEx expression parser\n"
@@ -168,6 +174,7 @@ public class ModConfig implements IPackable, IPacketProcessor {
     private static final String FOOD_CONTAINERS_MAX_STACKSIZE_NAME = "food.containers.max.stacksize";
     private static final int FOOD_CONTAINERS_MAX_STACKSIZE_DEFAULT = 2;
     private static final String FOOD_CONTAINERS_MAX_STACKSIZE_COMMENT = "The maximum stacksize per slot in a food container";
+
     /*
      * CLIENT
      */
@@ -201,6 +208,7 @@ public class ModConfig implements IPackable, IPacketProcessor {
     public static boolean AFFECT_NEGATIVE_FOOD_SATURATION_MODIFIERS = ModConfig.AFFECT_NEGATIVE_FOOD_SATURATION_MODIFIERS_DEFAULT;
     public static float FOOD_EATING_SPEED_MODIFIER = ModConfig.FOOD_EATING_SPEED_MODIFIER_DEFAULT;
     public static int FOOD_EATING_DURATION_MAX = ModConfig.FOOD_EATING_DURATION_MAX_DEFAULT;
+    public static boolean USE_HUNGER_QUEUE = USE_HUNGER_QUEUE_DEFAULT;
     public static String FOOD_MODIFIER_FORMULA = ModConfig.FOOD_MODIFIER_FORMULA_STRING_DEFAULT;
     public static boolean GIVE_FOOD_JOURNAL_ON_START = ModConfig.GIVE_FOOD_JOURNAL_ON_START_DEFAULT;
 
@@ -357,6 +365,7 @@ public class ModConfig implements IPackable, IPacketProcessor {
                 FOOD_EATING_DURATION_MAX_DEFAULT,
                 FOOD_EATING_DURATION_MAX_COMMENT)
             .getInt(FOOD_EATING_DURATION_MAX_DEFAULT);
+        USE_HUNGER_QUEUE = config.get(CATEGORY_SERVER, USE_HUNGER_QUEUE_NAME, USE_HUNGER_QUEUE_DEFAULT, USE_HUNGER_QUEUE_COMMENT).getBoolean(USE_HUNGER_QUEUE_DEFAULT);
         GIVE_FOOD_JOURNAL_ON_START = config
             .get(
                 CATEGORY_SERVER,

--- a/src/main/java/squeek/spiceoflife/foodtracker/FoodHistory.java
+++ b/src/main/java/squeek/spiceoflife/foodtracker/FoodHistory.java
@@ -21,6 +21,7 @@ import squeek.spiceoflife.ModInfo;
 import squeek.spiceoflife.compat.IByteIO;
 import squeek.spiceoflife.foodtracker.foodgroups.FoodGroup;
 import squeek.spiceoflife.foodtracker.foodgroups.FoodGroupRegistry;
+import squeek.spiceoflife.foodtracker.foodqueue.FixedHungerQueue;
 import squeek.spiceoflife.foodtracker.foodqueue.FixedSizeQueue;
 import squeek.spiceoflife.foodtracker.foodqueue.FoodQueue;
 import squeek.spiceoflife.helpers.FoodHelper;
@@ -90,7 +91,7 @@ public class FoodHistory implements IExtendedEntityProperties, ISaveable, IPacka
     }
 
     public static FoodQueue getNewFoodQueue() {
-        return new FixedSizeQueue(ModConfig.FOOD_HISTORY_LENGTH);
+        return ModConfig.USE_HUNGER_QUEUE ? new FixedHungerQueue(ModConfig.FOOD_HISTORY_LENGTH) : new FixedSizeQueue(ModConfig.FOOD_HISTORY_LENGTH);
     }
 
     public void deltaTicksActive(long delta) {
@@ -144,7 +145,7 @@ public class FoodHistory implements IExtendedEntityProperties, ISaveable, IPacka
     }
 
     public int getHistoryLength() {
-        return recentHistory.size();
+        return ModConfig.USE_HUNGER_QUEUE ? ((FixedHungerQueue) recentHistory).hunger() : recentHistory.size();
     }
 
     public FoodEaten getLastEatenFood() {

--- a/src/main/java/squeek/spiceoflife/foodtracker/FoodHistory.java
+++ b/src/main/java/squeek/spiceoflife/foodtracker/FoodHistory.java
@@ -91,7 +91,8 @@ public class FoodHistory implements IExtendedEntityProperties, ISaveable, IPacka
     }
 
     public static FoodQueue getNewFoodQueue() {
-        return ModConfig.USE_HUNGER_QUEUE ? new FixedHungerQueue(ModConfig.FOOD_HISTORY_LENGTH) : new FixedSizeQueue(ModConfig.FOOD_HISTORY_LENGTH);
+        return ModConfig.USE_HUNGER_QUEUE ? new FixedHungerQueue(ModConfig.FOOD_HISTORY_LENGTH)
+            : new FixedSizeQueue(ModConfig.FOOD_HISTORY_LENGTH);
     }
 
     public void deltaTicksActive(long delta) {

--- a/src/main/java/squeek/spiceoflife/foodtracker/foodqueue/FixedHungerQueue.java
+++ b/src/main/java/squeek/spiceoflife/foodtracker/foodqueue/FixedHungerQueue.java
@@ -1,0 +1,72 @@
+package squeek.spiceoflife.foodtracker.foodqueue;
+
+import squeek.spiceoflife.foodtracker.FoodEaten;
+
+public class FixedHungerQueue extends FixedSizeQueue
+{
+    private static final long serialVersionUID = -1347372098150405272L;
+    protected int hunger;
+    protected int hungerOverflow;
+
+    public FixedHungerQueue(int limit)
+    {
+        super(limit);
+    }
+
+    @Override
+    public boolean add(FoodEaten foodEaten)
+    {
+        boolean added = super.add(foodEaten);
+        if (added)
+        {
+            hunger += foodEaten.foodValues.hunger;
+            trimToMaxSize();
+        }
+        return added;
+    }
+
+    @Override
+    public void clear()
+    {
+        super.clear();
+        hunger = hungerOverflow = 0;
+    }
+
+    public int hunger()
+    {
+        return hunger;
+    }
+
+    public int totalHunger()
+    {
+        return hunger + hungerOverflow;
+    }
+
+    public FixedHungerQueue sliceUntil(FoodEaten target)
+    {
+        FixedHungerQueue slice = new FixedHungerQueue(limit);
+        for (FoodEaten foodEaten : this)
+        {
+            if (target.equals(foodEaten))
+                break;
+
+            slice.add(foodEaten);
+        }
+        return slice;
+    }
+
+    @Override
+    protected void trimToMaxSize()
+    {
+        while (hunger > limit && peekFirst() != null)
+        {
+            hunger -= 1;
+            hungerOverflow += 1;
+
+            while (hungerOverflow >= peekFirst().foodValues.hunger)
+            {
+                hungerOverflow -= removeFirst().foodValues.hunger;
+            }
+        }
+    }
+}

--- a/src/main/java/squeek/spiceoflife/foodtracker/foodqueue/FixedHungerQueue.java
+++ b/src/main/java/squeek/spiceoflife/foodtracker/foodqueue/FixedHungerQueue.java
@@ -4,7 +4,6 @@ import squeek.spiceoflife.foodtracker.FoodEaten;
 
 public class FixedHungerQueue extends FixedSizeQueue {
 
-    private static final long serialVersionUID = -1347372098150405272L;
     protected int hunger;
     protected int hungerOverflow;
 
@@ -30,20 +29,6 @@ public class FixedHungerQueue extends FixedSizeQueue {
 
     public int hunger() {
         return hunger;
-    }
-
-    public int totalHunger() {
-        return hunger + hungerOverflow;
-    }
-
-    public FixedHungerQueue sliceUntil(FoodEaten target) {
-        FixedHungerQueue slice = new FixedHungerQueue(limit);
-        for (FoodEaten foodEaten : this) {
-            if (target.equals(foodEaten)) break;
-
-            slice.add(foodEaten);
-        }
-        return slice;
     }
 
     @Override

--- a/src/main/java/squeek/spiceoflife/foodtracker/foodqueue/FixedHungerQueue.java
+++ b/src/main/java/squeek/spiceoflife/foodtracker/foodqueue/FixedHungerQueue.java
@@ -2,23 +2,20 @@ package squeek.spiceoflife.foodtracker.foodqueue;
 
 import squeek.spiceoflife.foodtracker.FoodEaten;
 
-public class FixedHungerQueue extends FixedSizeQueue
-{
+public class FixedHungerQueue extends FixedSizeQueue {
+
     private static final long serialVersionUID = -1347372098150405272L;
     protected int hunger;
     protected int hungerOverflow;
 
-    public FixedHungerQueue(int limit)
-    {
+    public FixedHungerQueue(int limit) {
         super(limit);
     }
 
     @Override
-    public boolean add(FoodEaten foodEaten)
-    {
+    public boolean add(FoodEaten foodEaten) {
         boolean added = super.add(foodEaten);
-        if (added)
-        {
+        if (added) {
             hunger += foodEaten.foodValues.hunger;
             trimToMaxSize();
         }
@@ -26,29 +23,23 @@ public class FixedHungerQueue extends FixedSizeQueue
     }
 
     @Override
-    public void clear()
-    {
+    public void clear() {
         super.clear();
         hunger = hungerOverflow = 0;
     }
 
-    public int hunger()
-    {
+    public int hunger() {
         return hunger;
     }
 
-    public int totalHunger()
-    {
+    public int totalHunger() {
         return hunger + hungerOverflow;
     }
 
-    public FixedHungerQueue sliceUntil(FoodEaten target)
-    {
+    public FixedHungerQueue sliceUntil(FoodEaten target) {
         FixedHungerQueue slice = new FixedHungerQueue(limit);
-        for (FoodEaten foodEaten : this)
-        {
-            if (target.equals(foodEaten))
-                break;
+        for (FoodEaten foodEaten : this) {
+            if (target.equals(foodEaten)) break;
 
             slice.add(foodEaten);
         }
@@ -56,15 +47,12 @@ public class FixedHungerQueue extends FixedSizeQueue
     }
 
     @Override
-    protected void trimToMaxSize()
-    {
-        while (hunger > limit && peekFirst() != null)
-        {
+    protected void trimToMaxSize() {
+        while (hunger > limit && peekFirst() != null) {
             hunger -= 1;
             hungerOverflow += 1;
 
-            while (hungerOverflow >= peekFirst().foodValues.hunger)
-            {
+            while (hungerOverflow >= peekFirst().foodValues.hunger) {
                 hungerOverflow -= removeFirst().foodValues.hunger;
             }
         }

--- a/src/main/java/squeek/spiceoflife/gui/TooltipHandler.java
+++ b/src/main/java/squeek/spiceoflife/gui/TooltipHandler.java
@@ -162,13 +162,19 @@ public class TooltipHandler {
                 + EnumChatFormatting.DARK_GRAY
                 + "]"
             : "";
-        if (count > 0) eatenRecently = StatCollector.translateToLocalFormatted(
-            "spiceoflife.tooltip.eaten.recently" + (ModConfig.USE_HUNGER_QUEUE ? ".hunger" : ""),
-
-            StringHelper.getQuantityDescriptor(count),
-            ModConfig.USE_HUNGER_QUEUE ? StringHelper.hungerHistoryLength(ModConfig.FOOD_HISTORY_LENGTH)
-                : ModConfig.FOOD_HISTORY_LENGTH);
-        else eatenRecently = StatCollector.translateToLocal("spiceoflife.tooltip.not.eaten.recently");
+        if (count > 0) {
+            if (ModConfig.USE_HUNGER_QUEUE) {
+                eatenRecently = StatCollector.translateToLocalFormatted(
+                    "spiceoflife.tooltip.eaten.recently.hunger",
+                    StringHelper.getQuantityDescriptor(count),
+                    StringHelper.hungerHistoryLength(ModConfig.FOOD_HISTORY_LENGTH));
+            } else {
+                eatenRecently = StatCollector.translateToLocalFormatted(
+                    "spiceoflife.tooltip.eaten.recently",
+                    StringHelper.getQuantityDescriptor(count),
+                    ModConfig.FOOD_HISTORY_LENGTH);
+            }
+        } else eatenRecently = StatCollector.translateToLocal("spiceoflife.tooltip.not.eaten.recently");
         return prefix + (foodGroup != null ? StringHelper.decapitalize(eatenRecently, StringHelper.getMinecraftLocale())
             : eatenRecently) + nutritionalValue;
     }

--- a/src/main/java/squeek/spiceoflife/gui/TooltipHandler.java
+++ b/src/main/java/squeek/spiceoflife/gui/TooltipHandler.java
@@ -163,10 +163,11 @@ public class TooltipHandler {
                 + "]"
             : "";
         if (count > 0) eatenRecently = StatCollector.translateToLocalFormatted(
-                "spiceoflife.tooltip.eaten.recently" + (ModConfig.USE_HUNGER_QUEUE ? ".hunger" : ""),
+            "spiceoflife.tooltip.eaten.recently" + (ModConfig.USE_HUNGER_QUEUE ? ".hunger" : ""),
 
             StringHelper.getQuantityDescriptor(count),
-                ModConfig.USE_HUNGER_QUEUE ? StringHelper.hungerHistoryLength(ModConfig.FOOD_HISTORY_LENGTH) : ModConfig.FOOD_HISTORY_LENGTH);
+            ModConfig.USE_HUNGER_QUEUE ? StringHelper.hungerHistoryLength(ModConfig.FOOD_HISTORY_LENGTH)
+                : ModConfig.FOOD_HISTORY_LENGTH);
         else eatenRecently = StatCollector.translateToLocal("spiceoflife.tooltip.not.eaten.recently");
         return prefix + (foodGroup != null ? StringHelper.decapitalize(eatenRecently, StringHelper.getMinecraftLocale())
             : eatenRecently) + nutritionalValue;

--- a/src/main/java/squeek/spiceoflife/gui/TooltipHandler.java
+++ b/src/main/java/squeek/spiceoflife/gui/TooltipHandler.java
@@ -163,9 +163,10 @@ public class TooltipHandler {
                 + "]"
             : "";
         if (count > 0) eatenRecently = StatCollector.translateToLocalFormatted(
-            "spiceoflife.tooltip.eaten.recently",
+                "spiceoflife.tooltip.eaten.recently" + (ModConfig.USE_HUNGER_QUEUE ? ".hunger" : ""),
+
             StringHelper.getQuantityDescriptor(count),
-            ModConfig.FOOD_HISTORY_LENGTH);
+                ModConfig.USE_HUNGER_QUEUE ? StringHelper.hungerHistoryLength(ModConfig.FOOD_HISTORY_LENGTH) : ModConfig.FOOD_HISTORY_LENGTH);
         else eatenRecently = StatCollector.translateToLocal("spiceoflife.tooltip.not.eaten.recently");
         return prefix + (foodGroup != null ? StringHelper.decapitalize(eatenRecently, StringHelper.getMinecraftLocale())
             : eatenRecently) + nutritionalValue;


### PR DESCRIPTION
This readds the config option to allow for hunger restored to be used as history, instead of the number of unique foods. Unsure if this was removed for balance reasons, if so feel free to close, but we use it in Blightfall so I figured I'd port it for there.