### PR TITLE
Fix fatal NPE

### DIFF
--- a/src/main/java/squeek/spiceoflife/gui/TooltipHandler.java
+++ b/src/main/java/squeek/spiceoflife/gui/TooltipHandler.java
@@ -150,9 +150,8 @@ public class TooltipHandler {
     public String getEatenRecentlyTooltip(FoodHistory foodHistory, ItemStack itemStack, FoodGroup foodGroup,
         boolean shouldShowNutritionalValue) {
         final int count = foodHistory.getFoodCountForFoodGroup(itemStack, foodGroup);
-        final String prefix = StatCollector.translateToLocal("spiceoflife.tooltip.diminishing")
-            + (" " + foodGroup != null ? foodGroup.formatString(EnumChatFormatting.ITALIC.toString() + foodGroup) + " "
-                : "")
+        final String prefix = StatCollector.translateToLocal("spiceoflife.tooltip.diminishing") + (" "
+            + (foodGroup != null ? foodGroup.formatString(EnumChatFormatting.ITALIC.toString() + foodGroup) + " " : ""))
             + EnumChatFormatting.RESET.toString()
             + EnumChatFormatting.DARK_AQUA.toString()
             + EnumChatFormatting.ITALIC;


### PR DESCRIPTION
Introduced in
https://github.com/GTNewHorizons/SpiceOfLife/blob/6abca32be8d44320d91af410d4bf847d06cc28be/src/main/java/squeek/spiceoflife/gui/TooltipHandler.java#L153-L154

at `" " + foodGroup != null`, causing the death of tooltips for every food item, displayed as `unnamed`

Extremely sorry for that.

This PR has been tested in my actual game, solved the mentioned problem.

@serenibyss please give it a check rq. much appreciation