### PR TITLE
Fix missing parens in null check

### DIFF
--- a/src/main/java/squeek/spiceoflife/gui/TooltipHandler.java
+++ b/src/main/java/squeek/spiceoflife/gui/TooltipHandler.java
@@ -150,9 +150,8 @@ public class TooltipHandler {
     public String getEatenRecentlyTooltip(FoodHistory foodHistory, ItemStack itemStack, FoodGroup foodGroup,
         boolean shouldShowNutritionalValue) {
         final int count = foodHistory.getFoodCountForFoodGroup(itemStack, foodGroup);
-        final String prefix = StatCollector.translateToLocal("spiceoflife.tooltip.diminishing")
-            + (" " + foodGroup != null ? foodGroup.formatString(EnumChatFormatting.ITALIC.toString() + foodGroup) + " "
-                : "")
+        final String prefix = StatCollector.translateToLocal("spiceoflife.tooltip.diminishing") + (" "
+            + (foodGroup != null ? foodGroup.formatString(EnumChatFormatting.ITALIC.toString() + foodGroup) + " " : ""))
             + EnumChatFormatting.RESET.toString()
             + EnumChatFormatting.DARK_AQUA.toString()
             + EnumChatFormatting.ITALIC;


### PR DESCRIPTION
Fixes this spam in the logs
```java
java.lang.NullPointerException: Cannot invoke "squeek.spiceoflife.foodtracker.foodgroups.FoodGroup.formatString(String)" because "foodGroup" is null
	at Launch//squeek.spiceoflife.gui.TooltipHandler.getEatenRecentlyTooltip(TooltipHandler.java:154) ~[TooltipHandler.class:?]
	at Launch//squeek.spiceoflife.gui.TooltipHandler.onItemTooltip(TooltipHandler.java:116) ~[TooltipHandler.class:?]
	at cpw.mods.fml.common.eventhandler.ASMEventHandler_1937_TooltipHandler_onItemTooltip_ItemTooltipEvent.invoke(.dynamic) ~[?:?]
	at Launch//cpw.mods.fml.common.eventhandler.ASMEventHandler.invoke(ASMEventHandler.java:54) ~[ASMEventHandler.class:?]
	at Launch//cpw.mods.fml.common.eventhandler.EventBus.post(EventBus.java:140) [EventBus.class:?]
	at Launch//net.minecraftforge.event.ForgeEventFactory.onItemTooltip(ForgeEventFactory.java:169) [ForgeEventFactory.class:?]
	at Launch//net.minecraft.item.ItemStack.func_82840_a(ItemStack.java:626) [add.class:?]
	at Launch//vazkii.botania.client.core.handler.TooltipAdditionDisplayHandler.render(TooltipAdditionDisplayHandler.java:65) [TooltipAdditionDisplayHandler.class:?]
	at Launch//vazkii.botania.client.core.handler.ClientTickHandler.renderTick(ClientTickHandler.java:54) [ClientTickHandler.class:?]
	at cpw.mods.fml.common.eventhandler.ASMEventHandler_1374_ClientTickHandler_renderTick_RenderTickEvent.invoke(.dynamic) [?:?]
	at Launch//cpw.mods.fml.common.eventhandler.ASMEventHandler.invoke(ASMEventHandler.java:54) [ASMEventHandler.class:?]
	at Launch//cpw.mods.fml.common.eventhandler.EventBus.post(EventBus.java:140) [EventBus.class:?]
	at Launch//cpw.mods.fml.common.FMLCommonHandler.onRenderTickEnd(FMLCommonHandler.java:340) [FMLCommonHandler.class:?]
	at Launch//net.minecraft.client.Minecraft.func_71411_J(Minecraft.java:1003) [bao.class:?]
	at Launch//net.minecraft.client.Minecraft.func_99999_d(Minecraft.java:898) [bao.class:?]
	at Launch//net.minecraft.client.main.Main.main(SourceFile:148) [Main.class:?]
	at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(Unknown Source) ~[?:?]
	at java.base/java.lang.reflect.Method.invoke(Unknown Source) ~[?:?]
	at System//net.minecraft.launchwrapper.Launch.rfb$realLaunch(Launch.java:250) [Launch.class:?]
	at System//net.minecraft.launchwrapper.Launch.launch(Launch.java:35) [Launch.class:?]
	at System//net.minecraft.launchwrapper.Launch.main(Launch.java:60) [Launch.class:?]
	at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(Unknown Source) ~[?:?]
	at java.base/java.lang.reflect.Method.invoke(Unknown Source) ~[?:?]
	at com.gtnewhorizons.retrofuturabootstrap.Main.main(Main.java:207) [lwjgl3ify-2.1.6-forgePatches.jar:?]
	at System//org.prismlauncher.launcher.impl.StandardLauncher.launch(StandardLauncher.java:105) [NewLaunch.jar:?]
	at System//org.prismlauncher.EntryPoint.listen(EntryPoint.java:129) [NewLaunch.jar:?]
	at System//org.prismlauncher.EntryPoint.main(EntryPoint.java:70) [NewLaunch.jar:?]
	```