### PR TITLE
Fix crash when opening lunch box from offhand

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -4,5 +4,6 @@ dependencies {
     // Last version compatible with Java 8
     shadowImplementation('com.udojava:EvalEx:2.6')
 
-    compile('com.github.GTNewHorizons:AppleCore:3.3.4:dev')
+    api('com.github.GTNewHorizons:AppleCore:3.3.7:dev')
+    runtimeOnlyNonPublishable("com.github.GTNewHorizons:NotEnoughItems:2.7.89-GTNH:dev")
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -14,7 +14,7 @@ modId = SpiceOfLife
 modGroup = squeek.spiceoflife
 
 # Whether to use modGroup as the maven publishing group.
-# Due to a history of using JitPack, the default is com.github.GTNewHorizons for all mods.
+# When false, com.github.GTNewHorizons is used.
 useModGroupForPublishing = false
 
 # Updates your build.gradle and settings.gradle automatically whenever an update is available.
@@ -50,10 +50,10 @@ enableGenericInjection = false
 # Generate a class with a String field for the mod version named as defined below.
 # If generateGradleTokenClass is empty or not missing, no such class will be generated.
 # If gradleTokenVersion is empty or missing, the field will not be present in the class.
-generateGradleTokenClass =
+generateGradleTokenClass = squeek.spiceoflife.Tags
 
 # Name of the token containing the project's current version to generate/replace.
-gradleTokenVersion = GRADLETOKEN_VERSION
+gradleTokenVersion = VERSION
 
 # [DEPRECATED] Mod ID replacement token.
 gradleTokenModId =
@@ -70,7 +70,7 @@ gradleTokenGroupName =
 # The string's content will be replaced with your mod's version when compiled. You should use this to specify your mod's
 # version in @Mod([...], version = VERSION, [...]).
 # Leave these properties empty to skip individual token replacements.
-replaceGradleTokenInFile = ModInfo.java
+replaceGradleTokenInFile =
 
 # In case your mod provides an API for other mods to implement you may declare its package here. Otherwise, you can
 # leave this property empty.
@@ -151,7 +151,7 @@ modrinthProjectId = spice-of-life-carrot-edition-unofficial
 #       type can be one of [project, version],
 #       and the name is the Modrinth project or version slug/id of the other mod.
 # Example: required-project:fplib;optional-project:gasstation;incompatible-project:gregtech
-# Note: GTNH Mixins is automatically set as a required dependency if usesMixins = true
+# Note: UniMixins is automatically set as a required dependency if usesMixins = true.
 modrinthRelations = required-project\:applecore-unofficial
 
 # Publishing to CurseForge requires you to set the CURSEFORGE_TOKEN environment variable to one of your CurseForge API tokens.

--- a/settings.gradle
+++ b/settings.gradle
@@ -17,7 +17,7 @@ pluginManagement {
 }
 
 plugins {
-    id 'com.gtnewhorizons.gtnhsettingsconvention' version '1.0.37'
+    id 'com.gtnewhorizons.gtnhsettingsconvention' version '1.0.43'
 }
 
 

--- a/src/main/java/squeek/spiceoflife/ModInfo.java
+++ b/src/main/java/squeek/spiceoflife/ModInfo.java
@@ -3,6 +3,6 @@ package squeek.spiceoflife;
 public final class ModInfo {
 
     public static final String MODID = "SpiceOfLife";
-    public static final String VERSION = "GRADLETOKEN_VERSION";
+    public static final String VERSION = Tags.VERSION;
     public static final String NETCHANNEL = ModInfo.MODID;
 }

--- a/src/main/java/squeek/spiceoflife/inventory/ContainerFoodContainer.java
+++ b/src/main/java/squeek/spiceoflife/inventory/ContainerFoodContainer.java
@@ -4,7 +4,6 @@ import java.util.UUID;
 
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.entity.player.InventoryPlayer;
-import net.minecraft.inventory.Slot;
 import net.minecraft.item.ItemStack;
 
 import squeek.spiceoflife.helpers.GuiHelper;
@@ -16,11 +15,13 @@ public class ContainerFoodContainer extends ContainerGeneric {
     public int slotsY;
     protected FoodContainerInventory foodContainerInventory;
     private final int heldSlotId;
+    private final InventoryPlayer playerInventory;
 
     public ContainerFoodContainer(InventoryPlayer playerInventory, FoodContainerInventory foodContainerInventory) {
         super(foodContainerInventory);
         this.foodContainerInventory = foodContainerInventory;
         this.heldSlotId = playerInventory.currentItem;
+        this.playerInventory = playerInventory;
 
         slotsX = (int) (GuiHelper.STANDARD_GUI_WIDTH / 2f
             - (inventory.getSizeInventory() * GuiHelper.STANDARD_SLOT_WIDTH / 2f));
@@ -49,11 +50,9 @@ public class ContainerFoodContainer extends ContainerGeneric {
     }
 
     public ItemStack findFoodContainerWithUUID(UUID uuid) {
-        for (Object inventorySlotObj : this.inventorySlots) {
-            Slot inventorySlot = (Slot) inventorySlotObj;
-            ItemStack itemStack = inventorySlot.getStack();
-            if (isFoodContainerWithUUID(itemStack, uuid)) {
-                return itemStack;
+        for (ItemStack stack : playerInventory.mainInventory) {
+            if (isFoodContainerWithUUID(stack, uuid)) {
+                return stack;
             }
         }
         return null;


### PR DESCRIPTION
The crash happens because it looks for the currently used lunchbox item in the `ContainerFoodContainer` of said lunch box which doesn't include the offhand slot. 
This simply changes it to look through the players main inventory which also happens to be the only possible location that the lunch box it's trying to locate can be.

Closes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/21390