### PR TITLE
Lunchbox Crash Prevention

### DIFF
--- a/src/main/java/squeek/spiceoflife/inventory/ContainerFoodContainer.java
+++ b/src/main/java/squeek/spiceoflife/inventory/ContainerFoodContainer.java
@@ -42,7 +42,9 @@ public class ContainerFoodContainer extends ContainerGeneric {
     @Override
     public void onContainerClosed(EntityPlayer player) {
         if (cachedUUID != null) {
-
+            // the client could have a different ItemStack than the one the
+            // container was initialized with (due to server syncing), so
+            // we need to find the new one
             if (player.worldObj.isRemote) {
                 setFoodContainerItemStack(findFoodContainerWithUUID(getUUID()));
             }

--- a/src/main/java/squeek/spiceoflife/inventory/ContainerFoodContainer.java
+++ b/src/main/java/squeek/spiceoflife/inventory/ContainerFoodContainer.java
@@ -16,12 +16,20 @@ public class ContainerFoodContainer extends ContainerGeneric {
     protected FoodContainerInventory foodContainerInventory;
     private final int heldSlotId;
     private final InventoryPlayer playerInventory;
+    private final UUID cachedUUID;
 
     public ContainerFoodContainer(InventoryPlayer playerInventory, FoodContainerInventory foodContainerInventory) {
         super(foodContainerInventory);
         this.foodContainerInventory = foodContainerInventory;
         this.heldSlotId = playerInventory.currentItem;
         this.playerInventory = playerInventory;
+
+        ItemStack stack = getItemStack();
+        UUID uuid = null;
+        if (stack != null && stack.getItem() instanceof ItemFoodContainer) {
+            uuid = ((ItemFoodContainer) stack.getItem()).getUUID(stack);
+        }
+        this.cachedUUID = uuid;
 
         slotsX = (int) (GuiHelper.STANDARD_GUI_WIDTH / 2f
             - (inventory.getSizeInventory() * GuiHelper.STANDARD_SLOT_WIDTH / 2f));
@@ -33,14 +41,18 @@ public class ContainerFoodContainer extends ContainerGeneric {
 
     @Override
     public void onContainerClosed(EntityPlayer player) {
-        // the client could have a different ItemStack than the one the
-        // container was initialized with (due to server syncing), so
-        // we need to find the new one
-        if (player.worldObj.isRemote) {
-            setFoodContainerItemStack(findFoodContainerWithUUID(getUUID()));
+        if (cachedUUID != null) {
+
+            if (player.worldObj.isRemote) {
+                setFoodContainerItemStack(findFoodContainerWithUUID(getUUID()));
+            }
+
         }
 
-        if (getItemStack() != null) ((ItemFoodContainer) getItemStack().getItem()).setIsOpen(getItemStack(), false);
+        ItemStack stack = getItemStack();
+        if (stack != null && stack.getItem() instanceof ItemFoodContainer) {
+            ((ItemFoodContainer) stack.getItem()).setIsOpen(stack, false);
+        }
 
         super.onContainerClosed(player);
     }
@@ -50,6 +62,8 @@ public class ContainerFoodContainer extends ContainerGeneric {
     }
 
     public ItemStack findFoodContainerWithUUID(UUID uuid) {
+        if (uuid == null) return null;
+
         for (ItemStack stack : playerInventory.mainInventory) {
             if (isFoodContainerWithUUID(stack, uuid)) {
                 return stack;
@@ -59,7 +73,7 @@ public class ContainerFoodContainer extends ContainerGeneric {
     }
 
     public UUID getUUID() {
-        return ((ItemFoodContainer) getItemStack().getItem()).getUUID(getItemStack());
+        return cachedUUID;
     }
 
     public ItemStack getItemStack() {
@@ -67,9 +81,10 @@ public class ContainerFoodContainer extends ContainerGeneric {
     }
 
     public boolean isFoodContainerWithUUID(ItemStack itemStack, UUID uuid) {
+        if (uuid == null) return false;
+
         return itemStack != null && itemStack.getItem() instanceof ItemFoodContainer
-            && ((ItemFoodContainer) itemStack.getItem()).getUUID(itemStack)
-                .equals(uuid);
+            && uuid.equals(((ItemFoodContainer) itemStack.getItem()).getUUID(itemStack));
     }
 
     @Override

--- a/src/main/java/squeek/spiceoflife/items/ItemFoodContainer.java
+++ b/src/main/java/squeek/spiceoflife/items/ItemFoodContainer.java
@@ -90,8 +90,6 @@ public class ItemFoodContainer extends Item implements INBTInventoryHaver, IEdib
     }
 
     public UUID getUUID(ItemStack itemStack) {
-        if (itemStack == null) return null;
-
         NBTTagCompound base = getOrInitBaseTag(itemStack);
         if (base == null) return null;
 

--- a/src/main/java/squeek/spiceoflife/items/ItemFoodContainer.java
+++ b/src/main/java/squeek/spiceoflife/items/ItemFoodContainer.java
@@ -147,7 +147,6 @@ public class ItemFoodContainer extends Item implements INBTInventoryHaver, IEdib
     }
 
     public void setIsOpen(ItemStack itemStack, boolean isOpen) {
-        if (itemStack == null) return;
         NBTTagCompound baseTag = getOrInitBaseTag(itemStack);
         if (baseTag == null) return;
         baseTag.setBoolean(TAG_KEY_OPEN, isOpen);

--- a/src/main/java/squeek/spiceoflife/items/ItemFoodContainer.java
+++ b/src/main/java/squeek/spiceoflife/items/ItemFoodContainer.java
@@ -2,7 +2,6 @@ package squeek.spiceoflife.items;
 
 import java.util.List;
 import java.util.Locale;
-import java.util.Random;
 import java.util.UUID;
 
 import net.minecraft.client.renderer.texture.IIconRegister;
@@ -48,7 +47,6 @@ import squeek.spiceoflife.network.PacketToggleFoodContainer;
 
 public class ItemFoodContainer extends Item implements INBTInventoryHaver, IEdible {
 
-    public static final Random random = new Random();
     public static final String TAG_KEY_INVENTORY = "Inventory";
     public static final String TAG_KEY_OPEN = "Open";
     public static final String TAG_KEY_UUID = "UUID";
@@ -92,13 +90,30 @@ public class ItemFoodContainer extends Item implements INBTInventoryHaver, IEdib
     }
 
     public UUID getUUID(ItemStack itemStack) {
-        return UUID.fromString(getOrInitBaseTag(itemStack).getString(TAG_KEY_UUID));
+        if (itemStack == null) return null;
+
+        NBTTagCompound base = getOrInitBaseTag(itemStack);
+        if (base == null) return null;
+
+        String uuidStr = base.getString(TAG_KEY_UUID);
+        try {
+            return UUID.fromString(uuidStr);
+        } catch (IllegalArgumentException e) {
+            UUID uuid = UUID.randomUUID();
+            base.setString(TAG_KEY_UUID, uuid.toString());
+            return uuid;
+        }
     }
 
     public NBTTagCompound getOrInitBaseTag(ItemStack itemStack) {
+        if (itemStack == null) return null;
         if (!itemStack.hasTagCompound()) itemStack.setTagCompound(new NBTTagCompound());
 
         NBTTagCompound baseTag = itemStack.getTagCompound();
+        if (baseTag == null) {
+            baseTag = new NBTTagCompound();
+            itemStack.setTagCompound(baseTag);
+        }
 
         if (!baseTag.hasKey(TAG_KEY_UUID)) baseTag.setString(
             TAG_KEY_UUID,
@@ -132,7 +147,9 @@ public class ItemFoodContainer extends Item implements INBTInventoryHaver, IEdib
     }
 
     public void setIsOpen(ItemStack itemStack, boolean isOpen) {
+        if (itemStack == null) return;
         NBTTagCompound baseTag = getOrInitBaseTag(itemStack);
+        if (baseTag == null) return;
         baseTag.setBoolean(TAG_KEY_OPEN, isOpen);
     }
 
@@ -183,7 +200,7 @@ public class ItemFoodContainer extends Item implements INBTInventoryHaver, IEdib
     public void tryPullFoodFrom(ItemStack itemStack, IInventory inventory, EntityPlayer player) {
         List<InventoryFoodInfo> foodsToPull = MealPrioritizationHelper
             .findBestFoodsForPlayerAccountingForVariety(player, inventory);
-        if (foodsToPull.size() > 0) {
+        if (!foodsToPull.isEmpty()) {
             FoodContainerInventory foodContainerInventory = getInventory(itemStack);
             for (InventoryFoodInfo foodToPull : foodsToPull) {
                 ItemStack stackInSlot = inventory.getStackInSlot(foodToPull.slotNum);
@@ -205,25 +222,24 @@ public class ItemFoodContainer extends Item implements INBTInventoryHaver, IEdib
     }
 
     public boolean isOpen(ItemStack itemStack) {
-        return itemStack.hasTagCompound() && itemStack.getTagCompound()
-            .getBoolean(TAG_KEY_OPEN);
+        return itemStack != null && itemStack.hasTagCompound()
+            && itemStack.getTagCompound()
+                .getBoolean(TAG_KEY_OPEN);
     }
 
     @Override
     public boolean onDroppedByPlayer(ItemStack itemStack, EntityPlayer player) {
-        if (!player.worldObj.isRemote && player.openContainer != null
-            && player.openContainer instanceof ContainerFoodContainer) {
+        if (!player.worldObj.isRemote && player.openContainer instanceof ContainerFoodContainer) {
             ContainerFoodContainer openFoodContainer = (ContainerFoodContainer) player.openContainer;
             UUID droppedUUID = getUUID(itemStack);
 
-            if (openFoodContainer.getUUID()
-                .equals(droppedUUID)) {
+            if (droppedUUID != null && droppedUUID.equals(openFoodContainer.getUUID())) {
                 // if the cursor item is the open food container, then it will create an infinite loop
                 // due to the container dropping the cursor item when it is closed
                 ItemStack itemOnTheCursor = player.inventory.getItemStack();
                 if (itemOnTheCursor != null && itemOnTheCursor.getItem() instanceof ItemFoodContainer) {
-                    if (((ItemFoodContainer) itemOnTheCursor.getItem()).getUUID(itemOnTheCursor)
-                        .equals(droppedUUID)) {
+                    UUID cursorUUID = ((ItemFoodContainer) itemOnTheCursor.getItem()).getUUID(itemOnTheCursor);
+                    if (cursorUUID != null && cursorUUID.equals(droppedUUID)) {
                         player.inventory.setItemStack(null);
                     }
                 }
@@ -240,6 +256,7 @@ public class ItemFoodContainer extends Item implements INBTInventoryHaver, IEdib
 
     public NBTTagCompound getInventoryTag(ItemStack itemStack) {
         NBTTagCompound baseTag = getOrInitBaseTag(itemStack);
+        if (baseTag == null) return new NBTTagCompound();
 
         if (!baseTag.hasKey(TAG_KEY_INVENTORY)) baseTag.setTag(TAG_KEY_INVENTORY, new NBTTagCompound());
 


### PR DESCRIPTION
This fixes a crash that could occur when closing Lunchbox GUI at the same time as another GUI like NEI or when closing lunchbox and inventory. I think during resync, the ItemStack becomes temporarily null & hence the UUID from that stack, causing an NPE.

This just caches the UUID and adds a bunch of null protection as well as a few IntelliJ suggestions because who am I to argue with IDE authority.

Tested in fullpack. Works.
Closes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/23239