### PR TITLE
Update NEI tooltip cache when food is eaten

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -5,5 +5,5 @@ dependencies {
     shadowImplementation('com.udojava:EvalEx:2.6')
 
     api('com.github.GTNewHorizons:AppleCore:3.3.9:dev')
-    runtimeOnlyNonPublishable("com.github.GTNewHorizons:NotEnoughItems:2.8.93-GTNH:dev")
+    devOnlyNonPublishable("com.github.GTNewHorizons:NotEnoughItems:2.8.93-GTNH:dev")
 }

--- a/src/main/java/squeek/spiceoflife/compat/NEICompat.java
+++ b/src/main/java/squeek/spiceoflife/compat/NEICompat.java
@@ -1,0 +1,17 @@
+package squeek.spiceoflife.compat;
+
+import net.minecraft.item.ItemStack;
+
+import codechicken.nei.search.TooltipFilter;
+import cpw.mods.fml.common.Loader;
+import cpw.mods.fml.common.Optional;
+
+public class NEICompat {
+
+    public static final boolean LOADED = Loader.isModLoaded("NotEnoughItems");
+
+    @Optional.Method(modid = "NotEnoughItems")
+    public static void updateTooltipCache(ItemStack stack) {
+        TooltipFilter.putItem(stack);
+    }
+}

--- a/src/main/java/squeek/spiceoflife/foodtracker/FoodTracker.java
+++ b/src/main/java/squeek/spiceoflife/foodtracker/FoodTracker.java
@@ -15,6 +15,7 @@ import cpw.mods.fml.common.network.FMLNetworkEvent.ClientConnectedToServerEvent;
 import cpw.mods.fml.relauncher.Side;
 import squeek.applecore.api.food.FoodEvent;
 import squeek.spiceoflife.ModConfig;
+import squeek.spiceoflife.compat.NEICompat;
 import squeek.spiceoflife.compat.PacketDispatcher;
 import squeek.spiceoflife.foodtracker.foodgroups.FoodGroupRegistry;
 import squeek.spiceoflife.items.ItemFoodJournal;
@@ -44,6 +45,12 @@ public class FoodTracker {
         foodEaten.foodValues = event.foodValues;
 
         FoodTracker.addFoodEatenByPlayer(foodEaten, event.player);
+    }
+
+    public static void onFoodEatenClient(FoodEaten foodEaten) {
+        if (NEICompat.LOADED && foodEaten.itemStack != null) {
+            NEICompat.updateTooltipCache(foodEaten.itemStack);
+        }
     }
 
     public static void addFoodEatenByPlayer(FoodEaten foodEaten, EntityPlayer player) {

--- a/src/main/java/squeek/spiceoflife/network/PacketFoodHistory.java
+++ b/src/main/java/squeek/spiceoflife/network/PacketFoodHistory.java
@@ -6,6 +6,7 @@ import cpw.mods.fml.relauncher.Side;
 import squeek.spiceoflife.compat.IByteIO;
 import squeek.spiceoflife.foodtracker.FoodEaten;
 import squeek.spiceoflife.foodtracker.FoodHistory;
+import squeek.spiceoflife.foodtracker.FoodTracker;
 
 public class PacketFoodHistory extends PacketBase {
 
@@ -59,6 +60,10 @@ public class PacketFoodHistory extends PacketBase {
             .forEach(foodHistory::addFoodRecent);
         this.foodHistory.getFullHistory()
             .forEach(foodHistory::addFoodFullHistory);
+
+        if (side == Side.CLIENT && !shouldOverwrite) {
+            FoodTracker.onFoodEatenClient(this.foodHistory.getLastEatenFood());
+        }
 
         return null;
     }


### PR DESCRIPTION
Tooltip search will now reflect updates to eaten foods in real time rather than only on login.